### PR TITLE
Changed change stream aggregation to ensure more even distribution of data

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This allows us to direct all events connected to the same document to the same p
 
 It's a `$match` aggregation:
 
-`{"$expr": {"$eq": [{"$mod": [{"$divide": [{"$toLong": {"$toDate": "$_id"}}, 1000]}, $NUMBER_OF_PARTITIONS]}, $PARTITION_ID]}}`
+`{"$expr": {"$eq": [{"$cond": ["$_id", {"$mod": [{"$abs": {"$toHashedIndexKey": "$_id"}}, $NUMBER_OF_PARTITIONS]}, -1]}, $PARTITION_ID]}}`
 ## How to use it?
 
 In order to use this library you need to do 2 things:

--- a/src/main/java/com/gravity9/mongocse/MongoExpressions.java
+++ b/src/main/java/com/gravity9/mongocse/MongoExpressions.java
@@ -1,12 +1,13 @@
 package com.gravity9.mongocse;
 
 import java.util.List;
+
+import org.bson.BsonString;
+import org.bson.BsonValue;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 
 class MongoExpressions {
-
-	private static final Integer TO_MILLIS = 1000;
 
 	static Bson expr(Bson expr) {
 		return new Document("$expr", expr);
@@ -23,19 +24,23 @@ class MongoExpressions {
 		return new Document("$mod", List.of(expr, value));
 	}
 
-	static Bson divide(Bson expr) {
-		return new Document("$divide", List.of(expr, TO_MILLIS));
+	static BsonString fullDocumentKey(String keyName) {
+		return new BsonString("$fullDocument." + keyName);
 	}
 
-	static Bson toLong(Bson expr) {
-		return new Document("$toLong", expr);
+	static BsonString documentKey(String keyName) {
+		return new BsonString("$documentKey." + keyName);
 	}
 
-	static Bson toDateFullDocumentKey(String keyName) {
-		return new Document("$toDate", "$fullDocument." + keyName);
+	static Bson abs(Bson expr) {
+		return new Document("$abs", expr);
 	}
 
-	static Bson toDateDocumentKey(String keyName) {
-		return new Document("$toDate", "$documentKey." + keyName);
+	static Bson toHashedIndexKey(BsonValue expr) {
+		return new Document("$toHashedIndexKey", expr);
+	}
+
+	static Bson cond(Object ifExpr, Object thenExpr, Object elseExpr) {
+		return new Document("$cond", List.of(ifExpr, thenExpr, elseExpr));
 	}
 }

--- a/src/test/java/com/gravity9/mongocse/AbstractMongoDbBase.java
+++ b/src/test/java/com/gravity9/mongocse/AbstractMongoDbBase.java
@@ -17,7 +17,7 @@ import java.util.List;
 public abstract class AbstractMongoDbBase {
 
     private static final MongoDBContainer MONGO_DB_CONTAINER =
-            new MongoDBContainer("mongo:4.2.8");
+            new MongoDBContainer("mongo:4.2.24");
     private static final String COLL_NAME = "testCollection";
     private static final String DB_NAME = "test";
 

--- a/src/test/java/com/gravity9/mongocse/constants/TestIds.java
+++ b/src/test/java/com/gravity9/mongocse/constants/TestIds.java
@@ -2,9 +2,9 @@ package com.gravity9.mongocse.constants;
 
 public class TestIds {
 
-	public static final String MOD_0_ID = "652e9f6fcd6b9a316b067843";
+	public static final String MOD_0_ID = "652e9fdc597d12ddbf7380e7";
 
-	public static final String MOD_1_ID = "652e9fdc597d12ddbf7380e7";
+	public static final String MOD_1_ID = "652e9f6fcd6b9a316b067843";
 
 	public static final String MOD_2_ID = "652ea13969adc932efb550d4";
 }


### PR DESCRIPTION
Changed change stream aggregation in order to ensure more even distribution of data between partitions.
Approach inspired by MongoDB [Hashed Indexes ](https://www.mongodb.com/docs/manual/core/indexes/index-types/index-hashed/) "_id" is hashed using [toHashedIndexKey](https://www.mongodb.com/docs/manual/reference/operator/aggregation/toHashedIndexKey/) function. One thing to consider is that this function is available in expressions since version [4.2.24](https://www.mongodb.com/docs/v4.4/release-notes/4.2-changelog/#4.2.24-changelog), but according to [Support Policy](https://www.mongodb.com/legal/support-policy/lifecycles) 4.2 already reached its End of Life Date, so hopefully it is not an issue.